### PR TITLE
DI-1801 Genie PR 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ liftOver
 *.fai
 *.csv
 *.tsv
+*.html
+!jinja_template.html

--- a/DI-1801/README.md
+++ b/DI-1801/README.md
@@ -1,0 +1,75 @@
+## DI-1801 Generate counts from Genie data
+This folder contains scripts to take Genie MAF data, aggregate counts of each variant,
+convert each variant to a VCF-like description and output to a CSV and VCF.
+
+### Subset Genie data
+The original Genie data has millions of rows, therefore we are going to subset the data to only
+variants in genies that are present in the haemonc BED file.
+Example command:
+```
+python subset_genie_data.py \
+  --input_maf data_mutations_extended.txt \
+  --bed_file GCF_000001405.39_GRCh38.p13_genomic_20200815.exons_20bp_5bp_uranus_panel_v1.0.0.bed \
+  --entrez_email my.email@nhs.net \
+  --extra_symbols GNAS-AS1 \
+  --output data_mutations_extended_haemonc_genes.txt
+```
+
+### Merge sample info
+We need to merge in the clinical data (patient IDs, cancer types etc.) so that we can generate
+count information.
+Example command:
+```
+python merge_sample_info.py \
+  --input_maf data_mutations_extended_haemonc_genes.txt \
+  --clinical_info data_clinical_sample.txt \
+  --output data_mutations_extended_haemonc_genes_clinical_info.txt
+```
+
+### Generate count data
+For each unique variant, generate counts for all cancers, all haemonc cancers and each
+haemonc cancer type, dependent on the input file of cancer types we're interested in.
+Example command:
+```
+python generate_count_data.py \
+  --input data_mutations_extended_haemonc_genes_clinical_info.txt \
+  --haemonc_cancer_types haemonc_cancer_types.txt \
+  --output genie_17_aggregated_counts_GRCh37.txt
+```
+
+### Convert counts to VCF
+Because each variant is in MAF-like format, in order to represent Genie variants in the same way
+as variants would be represented in a Uranus sample VCF, we want to convert them to a VCF-like
+description. This also means we can perform liftover to GRCh38 properly.
+A JSON file representing details of the fields to keep as INFO fields in the output VCF is required;
+an example `info_fields.json` is provided.
+Example command:
+```
+python convert_counts_to_vcf.py \
+  --input genie_17_aggregated_counts_GRCh37.txt \
+  --fasta Homo_sapiens.GRCh37.dna.toplevel.fa.gz \
+  --output_csv genie_17_aggregated_counts_GRCh37_vcf_description.csv \
+  --output_vcf genie_17_aggregated_counts_GRCh37.vcf \
+  --info_fields info_fields.json
+```
+
+### Add GRCh38 liftover to counts CSV
+To make a final CSV with GRCh38 lifted over variants and their aggregate counts, we want to read
+the VCF back into a dataframe and merge it with the CSV of counts in GRCh37.
+Example command:
+```
+python add_grch38_liftover.py \
+```
+
+### Create HTML table file
+From the output CSV, we want to generate a searchable HTML table with Tabulator.
+A JSON file representing the columns to keep in the HTML file from the Genie count data CSV
+is required; an example `columns.json` file is provided.
+Example command:
+```
+python create_html.py \
+    --input genie_17_aggregated_counts_GRCh38.csv \
+    --columns columns.json \
+    --template jinja_template.html \
+    --output genie_17_aggregated_counts_GRCh38.html
+```

--- a/DI-1801/add_grch38_liftover.py
+++ b/DI-1801/add_grch38_liftover.py
@@ -1,0 +1,163 @@
+import argparse
+import pandas as pd
+import pysam
+
+from utils import read_in_to_df
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command line arguments
+
+    Returns
+    -------
+    args : Namespace
+        Namespace of passed command line argument inputs
+    """
+    parser = argparse.ArgumentParser(
+        description="Information required to add GRCh38 lifted over variants"
+    )
+    parser.add_argument(
+        "--csv",
+        required=True,
+        type=str,
+        help="Path to CSV file to add GRCh38 lifted over variants to",
+    )
+
+    parser.add_argument(
+        "--vcf",
+        required=True,
+        type=str,
+        help="Path to VCF file which has been lifted over to GRCh38",
+    )
+
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=str,
+        help="Name of output CSV file with GRCh38 lifted over variants added",
+    )
+
+    return parser.parse_args()
+
+
+def read_vcf_to_df(vcf_file: str) -> pd.DataFrame:
+    """
+    Read in a VCF file into a dataframe.
+
+    Parameters
+    ----------
+    vcf_file : str
+        Path to the VCF file.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing the relevant columns from the VCF file.
+    """
+    vcf_in = pysam.VariantFile(vcf_file, "r")
+
+    # Store required data from GRCh38 VCF in a list of dictionaries then
+    # convert to a DataFrame
+    records = []
+    for rec in vcf_in:
+        row = {
+            "CHROM": str(rec.chrom),
+            "POS": int(rec.pos),
+            "REF": str(rec.ref),
+            "ALT": ",".join(str(a) for a in rec.alts),
+            "Genie_description": rec.info.get("Genie_description", None),
+        }
+
+        records.append(row)
+
+    vcf_df = pd.DataFrame(records)
+
+    return vcf_df
+
+
+def merge_dataframes(
+    b37_count_csv: pd.DataFrame, vcf_df: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Merge two dataframes on the common columns
+
+    Parameters
+    ----------
+    b37_count_csv : pd.DataFrame
+        DataFrame containing the b37 count CSV data.
+    vcf_df : pd.DataFrame
+        DataFrame containing the VCF data with GRCh38 lifted over.
+
+    Returns
+    -------
+    merged_df : pd.DataFrame
+        Merged DataFrame
+    """
+    merged_df = pd.merge(
+        b37_count_csv,
+        vcf_df,
+        left_on="variant_description",
+        right_on="Genie_description",
+        how="left",
+    )
+
+    merged_df = merged_df.rename(
+        columns={
+            "CHROM": "chrom_grch38",
+            "POS": "pos_grch38",
+            "REF": "ref_grch38",
+            "ALT": "alt_grch38",
+            "chrom_vcf": "chrom_grch37",
+            "pos_vcf": "pos_grch37",
+            "ref_vcf": "ref_grch37",
+            "alt_vcf": "alt_grch37",
+        }
+    )
+
+    priority_cols = [
+        "Hugo_Symbol",
+        "chrom_grch38",
+        "pos_grch38",
+        "ref_grch38",
+        "alt_grch38",
+        "Genie_description",
+        "HGVSc",
+        "HGVSp",
+        "RefSeq",
+        "Consequence",
+        "Variant_Classification",
+    ]
+    end_cols = [col for col in merged_df.columns if "_count" in col]
+    middle_cols = [
+        col for col in merged_df.columns if col not in priority_cols + end_cols
+    ]
+    merged_df = merged_df[priority_cols + middle_cols + end_cols]
+
+    return merged_df
+
+
+def main():
+    args = parse_args()
+    b37_count_csv = read_in_to_df(
+        args.csv,
+        sep=",",
+        header=0,
+    )
+    b37_count_csv["variant_description"] = (
+        b37_count_csv["Chromosome"].astype(str)
+        + "_"
+        + b37_count_csv["Start_Position"].astype(str)
+        + "_"
+        + b37_count_csv["Reference_Allele"].astype(str)
+        + "_"
+        + b37_count_csv["Tumor_Seq_Allele2"].astype(str)
+    )
+
+    vcf_df = read_vcf_to_df(args.vcf)
+    merged_df = merge_dataframes(b37_count_csv, vcf_df)
+    merged_df.to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/DI-1801/columns.json
+++ b/DI-1801/columns.json
@@ -18,16 +18,16 @@
         "headerFilter": "input"
     },
     {
-        "title": "chr_grch37",
-        "field": "Chromosome",
+        "title": "chrom_grch38",
+        "field": "chrom_grch38",
         "sorter": "string",
-        "width": 40,
+        "width": 50,
         "resizable": true,
         "headerFilter": "input"
     },
     {
-        "title": "start_grch37",
-        "field": "Start_Position",
+        "title": "pos_grch38",
+        "field": "pos_grch38",
         "sorter": "number",
         "width": 100,
         "resizable": true,
@@ -41,16 +41,72 @@
         }
     },
     {
-        "title": "chr_grch38",
-        "field": "GRCh38_chrom",
+        "title": "ref_grch38",
+        "field": "ref_grch38",
+        "sorter": "string",
+        "width": 150,
+        "resizable": true,
+        "headerFilter": "input"
+    },
+    {
+        "title": "alt_grch38",
+        "field": "alt_grch38",
+        "sorter": "string",
+        "width": 150,
+        "resizable": true,
+        "headerFilter": "input"
+    },
+    {
+        "title": "Genie_description",
+        "field": "Genie_description",
         "sorter": "string",
         "width": 200,
         "resizable": true,
         "headerFilter": "input"
     },
     {
-        "title": "start_grch38",
-        "field": "GRCh38_start",
+        "title": "HGVSc",
+        "field": "HGVSc",
+        "sorter": "string",
+        "width": 300,
+        "resizable": true,
+        "headerFilter": "input"
+    },
+    {
+        "title": "HGVSp",
+        "field": "HGVSp",
+        "sorter": "string",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input"
+    },
+    {
+        "title": "RefSeq",
+        "field": "RefSeq",
+        "sorter": "string",
+        "width": 150,
+        "resizable": true,
+        "headerFilter": "input"
+    },
+    {
+        "title": "Consequence",
+        "field": "Consequence",
+        "sorter": "string",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input"
+    },
+    {
+        "title": "Variant_Classification",
+        "field": "Variant_Classification",
+        "sorter": "string",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input"
+    },
+    {
+        "title": "all_cancers_count",
+        "field": "all_cancers_count",
         "sorter": "number",
         "width": 200,
         "resizable": true,
@@ -63,64 +119,288 @@
         }
     },
     {
-        "title": "ref",
-        "field": "Reference_Allele",
-        "sorter": "string",
-        "width": 80,
-        "resizable": true,
-        "headerFilter": "input"
-    },
-    {
-        "title": "alt",
-        "field": "Tumor_Seq_Allele2",
-        "sorter": "string",
-        "width": 80,
-        "resizable": true,
-        "headerFilter": "input"
-    },
-    {
-        "title": "hgvsc",
-        "field": "HGVSc",
-        "sorter": "string",
+        "title": "haemonc_cancers_count",
+        "field": "haemonc_cancers_count",
+        "sorter": "number",
         "width": 200,
         "resizable": true,
-        "headerFilter": "input"
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
     },
     {
-        "title": "hgvsp",
-        "field": "HGVSp",
-        "sorter": "string",
+        "title": "Blastic Plasmacytoid Dendritic Cell Neoplasm_count",
+        "field": "Blastic Plasmacytoid Dendritic Cell Neoplasm_count",
+        "sorter": "number",
         "width": 200,
         "resizable": true,
-        "headerFilter": "input"
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
     },
     {
-        "title": "refseq",
-        "field": "RefSeq",
-        "sorter": "string",
+        "title": "Blood Cancer, NOS_count",
+        "field": "Blood Cancer, NOS_count",
+        "sorter": "number",
         "width": 200,
         "resizable": true,
-        "headerFilter": "input"
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
     },
     {
-        "title": "consequence",
-        "field": "Consequence",
-        "sorter": "string",
+        "title": "Posttransplant Lymphoproliferative Disorders_count",
+        "field": "Posttransplant Lymphoproliferative Disorders_count",
+        "sorter": "number",
         "width": 200,
         "resizable": true,
-        "headerFilter": "input"
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
     },
     {
-        "title": "classification",
-        "field": "Variant_Classification",
-        "sorter": "string",
+        "title": "Non-Hodgkin Lymphoma_count",
+        "field": "Non-Hodgkin Lymphoma_count",
+        "sorter": "number",
         "width": 200,
         "resizable": true,
-        "headerFilter": "input"
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
     },
     {
-        "title": "all_cancers_count",
-        "field": "all_cancers_count",
+        "title": "Angiomatoid Fibrous Histiocytoma_count",
+        "field": "Angiomatoid Fibrous Histiocytoma_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Myelodysplastic/Myeloproliferative Neoplasms_count",
+        "field": "Myelodysplastic/Myeloproliferative Neoplasms_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Histiocytosis_count",
+        "field": "Histiocytosis_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Lymphatic Cancer_count",
+        "field": "Lymphatic Cancer_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Blood Cancer_count",
+        "field": "Blood Cancer_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Hodgkin Lymphoma_count",
+        "field": "Hodgkin Lymphoma_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Mature T and NK Neoplasms_count",
+        "field": "Mature T and NK Neoplasms_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Myelodysplastic Syndromes_count",
+        "field": "Myelodysplastic Syndromes_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Mastocytosis_count",
+        "field": "Mastocytosis_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "B-Lymphoblastic Leukemia/Lymphoma_count",
+        "field": "B-Lymphoblastic Leukemia/Lymphoma_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Lymphatic Cancer, NOS_count",
+        "field": "Lymphatic Cancer, NOS_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "T-Lymphoblastic Leukemia/Lymphoma_count",
+        "field": "T-Lymphoblastic Leukemia/Lymphoma_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Leukemia_count",
+        "field": "Leukemia_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Myeloproliferative Neoplasms_count",
+        "field": "Myeloproliferative Neoplasms_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Mature B-Cell Neoplasms_count",
+        "field": "Mature B-Cell Neoplasms_count",
+        "sorter": "number",
+        "width": 200,
+        "resizable": true,
+        "headerFilter": "input",
+        "formatter": "money",
+        "formatterParams": {
+            "precision": 0,
+            "symbol": "",
+            "thousand": ","
+        }
+    },
+    {
+        "title": "Myeloid Neoplasms with Germ Line Predisposition_count",
+        "field": "Myeloid Neoplasms with Germ Line Predisposition_count",
         "sorter": "number",
         "width": 200,
         "resizable": true,

--- a/DI-1801/convert_counts_to_vcf.py
+++ b/DI-1801/convert_counts_to_vcf.py
@@ -199,6 +199,10 @@ def convert_to_vcf_representation(genie_count_data, fasta):
         )
     )
 
+    genie_count_data["Consequence"] = genie_count_data[
+        "Consequence"
+    ].str.replace(",", "&")
+
     return genie_count_data
 
 
@@ -234,7 +238,7 @@ def write_variants_to_vcf(
             field["id"], field["number"], field["type"], field["description"]
         )
     header.info.add(
-        "Genie_original_description",
+        "Genie_description",
         "1",
         "String",
         "Original variant info from Genie",
@@ -262,15 +266,11 @@ def write_variants_to_vcf(
                 elif field_type == "Integer":
                     field_value = int(row[field_name])
 
-                if field_name == "Consequence":
-                    # Replace any commas with "&" to avoid VCF parsing issues
-                    # of commas
-                    field_value = field_value.replace(",", "&")
                 record.info[field["id"]] = field_value
 
         # Add in original Genie GRCh37 chrom-pos-ref-alt
         orig_coord_str = f"{row['Chromosome']}_{row['Start_Position']}_{row['Reference_Allele']}_{row['Tumor_Seq_Allele2']}"
-        record.info["Genie_original_description"] = orig_coord_str
+        record.info["Genie_description"] = orig_coord_str
 
         vcf_out.write(record)
 

--- a/DI-1801/templates/jinja_template.html
+++ b/DI-1801/templates/jinja_template.html
@@ -15,7 +15,7 @@
     <!-- end gtag.Google tag (js) -->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css" rel="stylesheet">
-    <title>simple variant database</title>
+    <title>Genie v17 count data</title>
 </head>
 
 <body>


### PR DESCRIPTION
Small changes:
- Add README with details of how to run each script
- Add script to add back in GRCh38 liftover of each variant to the CSV
- Update example JSON with fields to show in the Tabulator HTML
- Small change of what the INFO field is called which has the original Genie variant info in the VCF and convert commas to &s in the Consequence field for both the CSV and VCF (can't have commas in a VCF field)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/Haemonc_requests/19)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive README providing step-by-step user documentation for processing Genie MAF data to aggregated variant counts and HTML visualisation.
  - Introduced a script to add GRCh38 liftover information to variant count CSV files.

- **Improvements**
  - Expanded and updated the table column configuration to include new cancer-type count columns and adjusted existing column names and formatting.
  - Streamlined the handling of the "Consequence" field and unified INFO field naming in VCF outputs.
  - Updated the HTML template title to "Genie v17 count data" for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->